### PR TITLE
fix: RedisRegistry 修改为单例模式，之前有溢出bug

### DIFF
--- a/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
+++ b/dubbo-registry/dubbo-registry-redis/src/main/java/com/alibaba/dubbo/registry/redis/RedisRegistryFactory.java
@@ -18,15 +18,16 @@ package com.alibaba.dubbo.registry.redis;
 import com.alibaba.dubbo.common.URL;
 import com.alibaba.dubbo.registry.Registry;
 import com.alibaba.dubbo.registry.RegistryFactory;
+import com.alibaba.dubbo.registry.support.AbstractRegistryFactory;
 
 /**
  * RedisRegistryFactory
  * 
  * @author william.liangf
  */
-public class RedisRegistryFactory implements RegistryFactory {
+public class RedisRegistryFactory extends AbstractRegistryFactory {
 
-    public Registry getRegistry(URL url) {
+    public Registry createRegistry(URL url) {
         return new RedisRegistry(url);
     }
 


### PR DESCRIPTION
修复cti-cloud-console应用中高达582M的RedisRegistry相关的内存占用